### PR TITLE
Persistent ratings values

### DIFF
--- a/database/migrations/2022_07_03_105713_add_rating_sum_and_count_to_chapters_table.php
+++ b/database/migrations/2022_07_03_105713_add_rating_sum_and_count_to_chapters_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddRatingSumAndCountToChaptersTable extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up() {
+        Schema::table('chapters', function (Blueprint $table) {
+            $table->bigInteger('rating_sum', false, true)->default(0);
+            $table->bigInteger('rating_count', false, true)->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down() {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('rating_sum');
+            $table->dropColumn('rating_count');
+        });
+    }
+}


### PR DESCRIPTION
Actually only the average of ratings is cached.  
If someone clears the ratings table, all ratings of all chapters will be lost in the next table update.  

I want to cache sum and count of ratings too, in this way we can calculate the rating in any moment.